### PR TITLE
adding 'value' to wordlist spec

### DIFF
--- a/src/pycldf/components/FormTable-metadata.json
+++ b/src/pycldf/components/FormTable-metadata.json
@@ -25,6 +25,12 @@
                 "datatype": "string"
             }, 
             {
+                "name": "Value", 
+                "required": true, 
+                "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#value", 
+                "datatype": "string"
+            }, 
+            {
                 "name": "Form", 
                 "required": true, 
                 "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#lexicalUnit", 

--- a/src/pycldf/modules/Wordlist-metadata.json
+++ b/src/pycldf/modules/Wordlist-metadata.json
@@ -37,6 +37,12 @@
                         "datatype": "string"
                     }, 
                     {
+                        "name": "Value", 
+                        "required": true, 
+                        "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#lexicalUnit", 
+                        "datatype": "string"
+                    }, 
+                    {
                         "name": "Form", 
                         "required": true, 
                         "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#lexicalUnit", 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -99,6 +99,7 @@ def test_foreign_key_creation_two_fks_from_new_comp(ds):
             'ID': '1',
             'Language_ID': 'abc',
             'Parameter_ID': 'xyz',
+            'Value': 'value',
             'Form': 'form',
         }],
         BorrowingTable=[{
@@ -201,7 +202,7 @@ def test_add_component(ds_wl):
 
     ds_wl.write(
         FormTable=[
-            {'ID': '1', 'Form': 'form', 'Language_ID': 'l', 'Parameter_ID': 'p'}],
+            {'ID': '1', 'Value': 'value', 'Form': 'form', 'Language_ID': 'l', 'Parameter_ID': 'p'}],
         LanguageTable=[{'ID': 'l'}],
         ParameterTable=[{'ID': 'p'}])
     ds_wl.validate()


### PR DESCRIPTION
We are missing the "Value" parameter, which is crucial and should be required:

* Value is the raw data we get from sources, it could be empty, but most of the time, it is something witha comma or similar
* Value is converted to Form, and Form is used for segmentation

So all in all, we need this in the spec (given that it is also in our [ontology](http://cldf.clld.org/v1.0/terms.rdf#value)).