### PR TITLE
Use table urls as fallback names in SQL export.

### DIFF
--- a/src/pycldf/db.py
+++ b/src/pycldf/db.py
@@ -72,7 +72,6 @@ def insert(db, table, keys, *rows):
         keys = ['"{:}"'.format(k.replace('"', r'\"')) for k in keys]
         query = "INSERT INTO \"{0}\" ({1}) VALUES ({2})".format(
             table, ','.join(keys), ','.join(['?' for _ in keys]))
-        print(query)
         db.executemany(query, rows)
 
 
@@ -308,7 +307,6 @@ class TableSpec(object):
             clauses.append('FOREIGN KEY("{0}") REFERENCES "{1}"("{2}")'.format(
                 ','.join(fk), ref, ','.join(refcols)))
         query = "CREATE TABLE \"{0}\" (\n    {1}\n)".format(self.name, ',\n    '.join(clauses))
-        print(query)
         return query
 
 

--- a/src/pycldf/terms.py
+++ b/src/pycldf/terms.py
@@ -28,7 +28,7 @@ def term_uri(name, terms=None, ns=URL):
         name = sep.join([ns, name])
     if not terms or name in terms:
         return name
-
+    return None
 
 def qname(ns, lname):
     return '{%s}%s' % (ns, lname)


### PR DESCRIPTION
In order to do this:
 - Make sure all identifiers passed to SQLite are quoted, because then we can
   use the URL without modification as table name. SQLite is very lenient in the
   table names it permits.
 - Make ds.get_tabletype raise errors if no valid name was found, and deal with
   the changes this implies.
 - Remove the tabletype test in the schema generation.

Fixes #60.