### PR TITLE
trying to increase metadata.json stability

### DIFF
--- a/src/pycldf/dataset.py
+++ b/src/pycldf/dataset.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, print_function, division
 
 import sys
 from itertools import chain
-from collections import Counter
+from collections import Counter, OrderedDict
 
 from six import string_types
 
@@ -83,15 +83,15 @@ class GitRepository(object):
         self.dc = dc
 
     def json_ld(self):
-        res = {
-            'rdf:about': self.url,
-            'rdf:type': 'prov:Entity',
-        }
+        res = OrderedDict([
+            ('rdf:about', self.url),
+            ('rdf:type', 'prov:Entity'),
+        ])
         if self.version:
             res['dc:created'] = self.version
         elif self.clone:
             res['dc:created'] = git_describe(self.clone)
-        res.update({'dc:{0}'.format(k): v for k, v in self.dc.items()})
+        res.update({'dc:{0}'.format(k): self.dc[k] for k in sorted(self.dc)})
         return res
 
 


### PR DESCRIPTION
Noticed that a lot of the diffs have repeated re-orderings of `rdf:type` and `dc:created` elements. e.g. https://github.com/glottobank/grambank-cldf/commit/8b304d3505700701fd8ede87bc69e724d0bb4468

This PR tries to make the ordering of this robust and consistent to cut down diff churn


