### PR TITLE
Fix capitalisation of bibtex fields in createdb

### DIFF
--- a/src/pycldf/db.py
+++ b/src/pycldf/db.py
@@ -63,7 +63,7 @@ def translate(d, table, col=None):
 
 
 def clean_bibtex_key(s):
-    return s.replace('-', '_')
+    return s.replace('-', '_').lower()
 
 
 class Database(csvw.db.Database):

--- a/tests/data/ds1.bib
+++ b/tests/data/ds1.bib
@@ -1,8 +1,15 @@
 @article{meier2015,
 author = "hans meier",
-title = {some title}
+title = {some title},
+aDdress = {somewhere}
 }
 @misc{80086,
 title = {some title},
 extra_field = "content",
+address = {anywhere}
+}
+@misc{CapitalField,
+Title = {some title},
+extra_field = "content",
+Address = "not here"
 }

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -20,7 +20,7 @@ def test_db_write(tmpdir, data):
     db.write_from_tg()
     #shutil.copy(str(tmpdir.join('db.sqlite')), 'db.sqlite')
     assert len(db.query("select * from ValueTable where cldf_parameterReference = 'fid1'")) == 1
-    assert len(db.query('select * from SourceTable')) == 2
+    assert len(db.query('select * from SourceTable')) == 3
     assert len(db.query(
         "select valuetable_cldf_id from ValueTable_SourceTable where context = '2-5'")) == 1
 


### PR DESCRIPTION
This lower-cases all BibTeX fields, avoiding the duplication of `Journal` and `journal` etc. as described in #100.