### PR TITLE
return concatenated newick string instead of raising KeyError

### DIFF
--- a/src/pycldf/trees.py
+++ b/src/pycldf/trees.py
@@ -68,7 +68,7 @@ class Tree:
                 self.trees._parsed_files[self.file.id] = {
                     tree.name: tree.newick_string for tree in Nexus(content).TREES.trees}
 
-        return self.trees._parsed_files[self.file.id][self.name]
+        return ";".join(self.trees._parsed_files[self.file.id].values())
 
     def newick(self,
                d: typing.Optional[pathlib.Path] = None,


### PR DESCRIPTION
The dict `self.trees._parsed_files[self.file.id]` has keys `"1"`, `"2"` etc. The return statement OTOH assumes a key that contains the tree ID, resulting in a KeyError. I've attached a [MWE dataset](https://github.com/cldf/pycldf/files/12320425/cldf-tree-mwe.zip) where validation fails because of this.

I assumed that the newick string should contain `;`-separated trees if there are multiple.
