### PR TITLE
Fix error with simplepybtex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The `pycldf` package adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+- Switch from `pybtex` to `simplepybtex`.
+- Make `Dataset.add_sources` accept a `BibliographyData` object from either `pybtex` or `simplepybtex`.
+- More informative error message when `Dataset.add_sources` gets the wrong type of object.
 
 ## [1.42.0] - 2025-04-07
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,7 @@ install_requires =
     clldutils>=3.9
     uritemplate>=3.0
     python-dateutil
-    # pybtex requires setuptools, but doesn't seem to declare this.
-    setuptools
-    pybtex
+    simplepybtex
     newick
     commonnexus>=1.2.0
     python-frontmatter

--- a/src/pycldf/sources.py
+++ b/src/pycldf/sources.py
@@ -220,7 +220,7 @@ class Sources(object):
     def _add_entries(self, data, **kw):
         if isinstance(data, Source):
             entries = [(data.id, data.entry)]
-        elif isinstance(data, database.BibliographyData):
+        elif hasattr(data, 'entries'):
             entries = data.entries.items()
         else:
             raise ValueError(data)

--- a/src/pycldf/sources.py
+++ b/src/pycldf/sources.py
@@ -223,7 +223,12 @@ class Sources(object):
         elif hasattr(data, 'entries'):
             entries = data.entries.items()
         else:
-            raise ValueError(data)
+            msg = (
+                'expected `clldutils.source.Source`,'
+                ' `pybtex.database.BibliographyData`,'
+                ' or `simplepybtex.database.BibliographyData`;'
+                f' got {type(data)}'
+            raise TypeError(data)
 
         for key, entry in entries:
             if kw.get('_check_id', False) and not ID_PATTERN.match(key):

--- a/src/pycldf/sources.py
+++ b/src/pycldf/sources.py
@@ -9,8 +9,8 @@ from urllib.error import HTTPError
 from urllib.request import urlopen, urlretrieve
 
 from csvw.metadata import is_url
-from pybtex import database
-from pybtex.database.output.bibtex import Writer as BaseWriter
+from simplepybtex import database
+from simplepybtex.database.output.bibtex import Writer as BaseWriter
 from clldutils.source import Source as BaseSource
 from clldutils.source import ID_PATTERN
 
@@ -58,10 +58,10 @@ class Source(BaseSource):
     @classmethod
     def from_entry(cls, key, entry, **_kw):
         """
-        Create a `cls` instance from a `pybtex` entry object.
+        Create a `cls` instance from a `simplepybtex` entry object.
 
         :param key: BibTeX citation key of the entry
-        :param entry: `pybtex.database.Entry` instance
+        :param entry: `simplepybtex.database.Entry` instance
         :param _kw: Non-bib-metadata keywords to be passed for `cls` instantiation
         :return: `cls` instance
         """
@@ -227,7 +227,7 @@ class Sources(object):
                 'expected `clldutils.source.Source`,'
                 ' `pybtex.database.BibliographyData`,'
                 ' or `simplepybtex.database.BibliographyData`;'
-                f' got {type(data)}'
+                f' got {type(data)}')
             raise TypeError(data)
 
         for key, entry in entries:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2,7 +2,7 @@ import zipfile
 from urllib.error import HTTPError
 
 import pytest
-from pybtex.database import Entry
+from simplepybtex.database import Entry
 
 from pycldf.sources import Sources, Source, Reference
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -74,7 +74,7 @@ def test_Sources(bib):
     refs = ['huber2005[1-6]', 'Obrazy', 'Elegie[34]']
     assert src.format_refs(*list(src.expand_refs(refs))) == refs
     assert '%s' % src['huber2005'] == 'Huber, Herrmann. 2005. y.'
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         src.add(5)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
*Database.add_sources* expected a *BibliographyData* object from *pybtex* specifically and raised a *ValueError* when it got one from *simplepybtex*.

Changes made:

 * Fixed `Database.add_sources` so that you can duck-type either `BibliographyData` object into it.
 * Made error message more informative.
 * Changed error type from *ValueError* to *TypeError* because that just seems more appropriate here.
 * Might as well make the switch from *pybtex* to *simplepybtex*.

I think the thing that I'm most unsure about is changing the type of the exception because that's *technically* changing the API.  Then again, users probably shouldn't catch and handle a type error at run time anyways and just pass in the right type to begin with.
